### PR TITLE
Change order of arguments passed to the sonar_scanner executable.

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -112,7 +112,7 @@ def _sonarqube_impl(ctx):
             "echo 'Dereferencing bazel runfiles symlinks for accurate SCM resolution...'",
             "for f in $(find $(dirname %s) -type l); do sed -i '' $f; done" % sq_properties_file.short_path,
             "echo '... done.'",
-            "exec %s -Dproject.settings=%s $@" % (ctx.executable.sonar_scanner.short_path, sq_properties_file.short_path),
+            "exec %s $@ -Dproject.settings=%s" % (ctx.executable.sonar_scanner.short_path, sq_properties_file.short_path),
         ]),
         is_executable = True,
     )


### PR DESCRIPTION
This allows the user to pass flags to the java process and not just
the sonar_scanner.

(e.g. bazel run :sonarqube -- --jvm-flags="-Djavax.net.ssl.trustStore=/etc/mytruststore.ts" -Dscanner.settings=/etc/sonar/sonar-scanner.properties)