### PR TITLE
Add support for using "test_suite" rules in the "test_targets" attrib…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ sonarqube(
     coverage_report = ":coverage_report",
     scm_info = [":git"],
     tags = ["manual"],
+    testonly = True,
 )
 ```
 
@@ -144,10 +145,12 @@ sq_project(
     test_targets = [
         "//path/to/component:FirstComponentTest",
         "//path/to/component:SecondComponentTest",
+        "//path/to/component:TestSuite",
     ],
     test_reports = ["//:test_reports"],
     tags = ["manual"],
     visibility = ["//visibility:public"],
+    testonly = True,
 )
 ```
 

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -35,4 +35,5 @@ sonarqube(
     scm_info = [":git"],
     tags = ["manual"],
     targets = [],
+    testonly = True,
 )

--- a/examples/java/WORKSPACE
+++ b/examples/java/WORKSPACE
@@ -23,10 +23,11 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:specs.bzl", "maven")
 
 maven_install(
     artifacts = [
-        "junit:junit:4.12",
+        maven.artifact("junit", "junit", "4.12", testonly=True)
     ],
     repositories = [
         "https://jcenter.bintray.com/",

--- a/examples/java/subproject/BUILD
+++ b/examples/java/subproject/BUILD
@@ -9,6 +9,13 @@ sq_project(
     targets = ["//subproject/src/main/java/com/example:app"],
     test_reports = ["//:test_reports"],
     test_srcs = ["//subproject/src/test/java/com/example:java_test_srcs"],
-    test_targets = ["//subproject/src/test/java/com/example:AppTest"],
+    test_targets = [
+        # can use test_suite to reference multiple tests
+        "//subproject/src/test/java/com/example:mySuite",
+
+        # or individually like before
+        "//subproject/src/test/java/com/example:AppTest3",
+    ],
     visibility = ["//visibility:public"],
+    testonly = True,
 )

--- a/examples/java/subproject/src/test/java/com/example/AppTest2.java
+++ b/examples/java/subproject/src/test/java/com/example/AppTest2.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AppTest2 {
+    @Test
+    public void getMessage() {
+        App app = new App();
+        assertEquals("Default message is valid", app.getMessage(), "Hello World!");
+    }
+}

--- a/examples/java/subproject/src/test/java/com/example/AppTest3.java
+++ b/examples/java/subproject/src/test/java/com/example/AppTest3.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AppTest3 {
+    @Test
+    public void getMessage() {
+        App app = new App();
+        assertEquals("Default message is valid", app.getMessage(), "Hello World!");
+    }
+}

--- a/examples/java/subproject/src/test/java/com/example/BUILD
+++ b/examples/java/subproject/src/test/java/com/example/BUILD
@@ -4,12 +4,42 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+test_suite(
+    name = "mySuite",
+    tests = [
+        ":AppTest",
+        ":AppTest2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 java_test(
     name = "AppTest",
-    srcs = [":java_test_srcs"],
-    visibility = ["//visibility:public"],
+    srcs = ["AppTest.java"],
     deps = [
         "//subproject/src/main/java/com/example:app",
         "@maven//:junit_junit",
     ],
+    size = "small",
+)
+
+java_test(
+    name = "AppTest2",
+    srcs = ["AppTest2.java"],
+    deps = [
+        "//subproject/src/main/java/com/example:app",
+        "@maven//:junit_junit",
+    ],
+    size = "small",
+)
+
+java_test(
+    name = "AppTest3",
+    srcs = ["AppTest3.java"],
+    deps = [
+        "//subproject/src/main/java/com/example:app",
+        "@maven//:junit_junit",
+    ],
+    size = "small",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
…ute.

The change uses an aspect to find the *_test targets recursively via the "tests" attribute of "test_suite".  Using the "tags" attribute of "test_suite" is not supported.