### PR TITLE
Make Github workflow for creating a release

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly new_version=$1
+readonly release_archive="bazel_sonarqube.$new_version.tar.gz"
+
+sha=$(shasum -a 256 "$release_archive" | cut -d " " -f1)
+
+cat <<EOF
+## What's Changed
+
+TODO
+
+### MODULE.bazel Snippet
+
+\`\`\`bzl
+bazel_dep(name = "bazel_sonarqube", version = "$new_version", repo_name = "bazel_sonarqube")
+\`\`\`
+
+### Workspace Snippet
+
+\`\`\`bzl
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_sonarqube",
+    sha256 = "$sha",
+    url = "https://github.com/Zetten/bazel-sonarqube/releases/download/$new_version/bazel_sonarqube.$new_version.tar.gz",
+)
+
+load(
+    "@bazel_sonarqube//:repositories.bzl",
+    "bazel_sonarqube_repositories"
+)
+
+bazel_sonarqube_repositories()
+\`\`\`
+EOF

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,26 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The new version to tag, ex: 1.0.5'
+        required: true
+        type: string
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Release
+        run: |
+          set -euo pipefail
+
+          COPYFILE_DISABLE=1 tar czvf "bazel_sonarqube.$TAG.tar.gz" ./*
+          ./.github/generate-notes.sh "$TAG" | tee notes.md
+          gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "bazel_sonarqube.$TAG.tar.gz"
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel_sonarqube",
-    version = "1.0.0",
+    version = "1.0.1",
     compatibility_level = 1,
     repo_name = "bazel_sonarqube",
 )


### PR DESCRIPTION
@Zetten after merging this, can you tag the next version without leading "v". So the new git tag will be "1.0.1" instead of "v1.0.1". It is easier to manage since I don't believe that bzlmod allows non-numeric characters in version string.