### PR TITLE
Updated to work with Bazel 8.x.x

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1", repo_name = "bazel_skylib")
+bazel_dep(name = "rules_java", version = "8.11.0")
 
 bazel_dep(
     name = "stardoc",

--- a/defs.bzl
+++ b/defs.bzl
@@ -4,6 +4,7 @@ Rules to analyse Bazel projects with SonarQube.
 
 load("@bazel_version//:bazel_version.bzl", "bazel_version")
 load("@bazel_skylib//lib:versions.bzl", "versions")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 def sonarqube_coverage_generator_binary(name = None):
     if versions.is_at_least(threshold = "2.1.0", version = bazel_version):
@@ -11,7 +12,7 @@ def sonarqube_coverage_generator_binary(name = None):
     else:
         deps = ["@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:all_lcov_merger_lib"]
 
-    native.java_binary(
+    java_binary(
         name = "sonarqube_coverage_generator",
         srcs = [
             "src/main/java/com/google/devtools/coverageoutputgenerator/SonarQubeCoverageGenerator.java",


### PR DESCRIPTION
`native.java_binary` became deprecated with Bazel 8.x.x, it will be completely removed with (Bazel 9.x.x) [(Bazel roadmap)](https://bazel.build/about/roadmap#migration_of_android_c_java_python_and_proto_rules) Here is a proposed update to address the issue. `sonarqube_coverage_generator_binary` now relies on a starlark-based dependency approach, replacing the `native` with rule `load()`. This should guarantee forward 

#### Reproducing the error
Add this flag (in `.bazelrc` for instance): `--incompatible_autoload_externally=`
Run `$ bazel query @bazel_sonarqube`

Error: 
`ERROR: .cache/bazel/3748b155de36baa32ce7344936606de6/external/bazel_sonarqube+/BUILD.bazel:19:36: @@bazel_sonarqube+//:sonarqube_coverage_generator: no such attribute 'srcs' in 'java_binary' rule
ERROR: .cache/bazel/3748b155de36baa32ce7344936606de6/external/bazel_sonarqube+/BUILD.bazel:19:36: @@bazel_sonarqube+//:sonarqube_coverage_generator: no such attribute 'main_class' in 'java_binary' rule
ERROR: .cache/bazel/3748b155de36baa32ce7344936606de6/external/bazel_sonarqube+/BUILD.bazel:19:36: @@bazel_sonarqube+//:sonarqube_coverage_generator: no such attribute 'deps' in 'java_binary' rule
ERROR: no such target '@@bazel_sonarqube+//:bazel_sonarqube': target 'bazel_sonarqube' not declared in package '' defined by .cache/bazel/3748b155de36baa32ce7344936606de6/external/bazel_sonarqube+/BUILD.bazel`