### PR TITLE
Upgrade sonar_scanner_cli_version to 5.0.2 to add support for newer j…

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -2,10 +2,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def bazel_sonarqube_repositories(
         bazel_version_repository_name = "bazel_version",
-        sonar_scanner_cli_version = "4.8.1.3023",
-        sonar_scanner_cli_sha256 = "f0c10b64e6b9bf2a9f65c3abacfb04522d36e14b3a4edb87e48a9af84ca4260d",
-        bazel_skylib_version = "1.6.1",
-        bazel_skylib_sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2"):
+        sonar_scanner_cli_version = "5.0.2.4997",
+        sonar_scanner_cli_sha256 = "2f10fe6ac36213958201a67383c712a587e3843e32ae1edf06f01062d6fd147",
+        bazel_skylib_version = "1.8.1",
+        bazel_skylib_sha256 = "51b5105a760b353773f904d2bbc5e664d0987fbaf22265164de65d43e910d8ac"):
     http_archive(
         name = "org_sonarsource_scanner_cli_sonar_scanner_cli",
         build_file = "@bazel_sonarqube//:BUILD.sonar_scanner",


### PR DESCRIPTION
…ava versions

Currently when Java 21 is used, the error is displayed:
```
    Error: LinkageError occurred while loading main class org.sonarsource.scanner.cli.Main
        java.lang.UnsupportedClassVersionError: org/sonarsource/scanner/cli/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

This commit upgrades sonar_scanner_cli version and add support for newer version of Java.

Release notes for sonar-scanner-cli 5.0.2.4997:
https://github.com/SonarSource/sonar-scanner-cli/releases/tag/5.0.2.4997

This release is upgrading  okhttp/okio, which is fixing security issue:
https://nvd.nist.gov/vuln/detail/CVE-2023-3635