### PR TITLE
Allow for build on not macOS systems

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples/

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def bazel_sonarqube_repositories(
         bazel_version_repository_name = "bazel_version",
         sonar_scanner_cli_version = "5.0.2.4997",
-        sonar_scanner_cli_sha256 = "2f10fe6ac36213958201a67383c712a587e3843e32ae1edf06f01062d6fd147",
+        sonar_scanner_cli_sha256 = "2f10fe6ac36213958201a67383c712a587e3843e32ae1edf06f01062d6fd1407",
         bazel_skylib_version = "1.8.1",
         bazel_skylib_sha256 = "51b5105a760b353773f904d2bbc5e664d0987fbaf22265164de65d43e910d8ac"):
     http_archive(


### PR DESCRIPTION
During simple query the error is displayed:

            $ bazel query ...
            ERROR: error loading package under directory '': error loading package 'examples/swift': Unable to find package for @@[unknown repo 'rules_xcodeproj' requested from @@]//xcodeproj:defs.bzl: The repository '@@[unknown repo 'rules_xcodeproj' requested from @@]' could not be resolved: No repository visible as '@rules_xcodeproj' from main repository.
            Loading: 0 packages loaded
                currently loading:  ... (4 packages)
                Fetching repository @@_main~non_module_dependencies~bazel_version; starting
    

This commit is resolving it by ignoring examples directory