### PR TITLE
feat: pass attributes to the coverage generator target

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -6,20 +6,21 @@ load("@bazel_version//:bazel_version.bzl", "bazel_version")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@rules_java//java:defs.bzl", "java_binary")
 
-def sonarqube_coverage_generator_binary(name = None):
+def sonarqube_coverage_generator_binary(name = "sonarqube_coverage_generator", **kwargs):
     if versions.is_at_least(threshold = "2.1.0", version = bazel_version):
         deps = ["@remote_coverage_tools//:all_lcov_merger_lib"]
     else:
         deps = ["@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:all_lcov_merger_lib"]
 
     java_binary(
-        name = "sonarqube_coverage_generator",
+        name = name,
         srcs = [
             "src/main/java/com/google/devtools/coverageoutputgenerator/SonarQubeCoverageGenerator.java",
             "src/main/java/com/google/devtools/coverageoutputgenerator/SonarQubeCoverageReportPrinter.java",
         ],
         main_class = "com.google.devtools.coverageoutputgenerator.SonarQubeCoverageGenerator",
         deps = deps,
+        **kwargs,
     )
 
 TargetInfo = provider(


### PR DESCRIPTION
Allow passing attributes (such as `tags` or `visibility`) to the coverage generator target.