### PR TITLE
feat: make //:sonarqube_coverage_generator public

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -20,6 +20,7 @@ def sonarqube_coverage_generator_binary(name = None):
         ],
         main_class = "com.google.devtools.coverageoutputgenerator.SonarQubeCoverageGenerator",
         deps = deps,
+        visibility = ["//visibility:public"],
     )
 
 TargetInfo = provider(


### PR DESCRIPTION
This allows users to wrap it in another rule (such as an alias or to perform a transition).