### PR TITLE
fix: use with Bazel v9

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -4,7 +4,7 @@ Rules to analyse Bazel projects with SonarQube.
 
 load("@bazel_version//:bazel_version.bzl", "bazel_version")
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_binary")
 
 def sonarqube_coverage_generator_binary(name = None):
     if versions.is_at_least(threshold = "2.1.0", version = bazel_version):


### PR DESCRIPTION
Adds a missing import of JavaInfo provider for Bazel v9