### PR TITLE
Add missing rules_java imports

### DIFF
--- a/BUILD.sonar_scanner
+++ b/BUILD.sonar_scanner
@@ -1,3 +1,6 @@
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_import.bzl", "java_import")
+
 java_import(
     name = "_sonar_scanner_lib",
     jars = glob(["lib/**/*.jar"]),


### PR DESCRIPTION
Add missing rules_java imports.

Without It I get an error when using bazel cquery:


```
ERROR: /Users/vertexwahn/Library/Caches/bazel/_bazel_vertexwahn/956c0c3e6f9b1a72074211d112a3eca8/external/bazel_sonarqube++non_module_dependencies+org_sonarsource_scanner_cli_sonar_scanner_cli/BUILD.bazel:7:12: @@bazel_sonarqube++non_module_dependencies+org_sonarsource_scanner_cli_sonar_scanner_cli//:sonar_scanner: no such attribute 'runtime_deps' in 'java_binary' rule
ERROR: /Users/vertexwahn/Library/Caches/bazel/_bazel_vertexwahn/956c0c3e6f9b1a72074211d112a3eca8/external/bazel_sonarqube+/BUILD.bazel:21:6: Target '@@bazel_sonarqube++non_module_dependencies+org_sonarsource_scanner_cli_sonar_scanner_cli//:sonar_scanner' contains an error and its package is in error and referenced by '@@bazel_sonarqube+//:sonar_scanner'
ERROR: Analysis of target '//:sonarqube' failed; build aborted: Analysis failed
```